### PR TITLE
make parsers primarily heap-allocated, support cyclic references, etc.

### DIFF
--- a/src/combn/combinator/always.zig
+++ b/src/combn/combinator/always.zig
@@ -32,6 +32,10 @@ pub fn Always(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: AlwaysContext(Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             _ = freed;
             const self = @fieldParentPtr(Self, "parser", parser);

--- a/src/combn/combinator/always.zig
+++ b/src/combn/combinator/always.zig
@@ -22,7 +22,7 @@ pub fn AlwaysContext(comptime Value: type) type {
 /// The `input` value is taken ownership of by the parser, and deinitialized once the parser is.
 pub fn Always(comptime Payload: type, comptime Value: type) type {
     return struct {
-        parser: Parser(Payload, Value) = Parser(Payload, Value).init(parse, nodeName, deinit),
+        parser: Parser(Payload, Value) = Parser(Payload, Value).init(parse, nodeName, deinit, null),
         input: AlwaysContext(Value),
 
         const Self = @This();
@@ -32,7 +32,8 @@ pub fn Always(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
-        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator) void {
+        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
+            _ = freed;
             const self = @fieldParentPtr(Self, "parser", parser);
             if (self.input) |input| input.deinit(allocator);
         }
@@ -69,7 +70,7 @@ test "always" {
         defer ctx.deinit();
 
         const noop = try Always(Payload, AlwaysVoid).init(allocator, null);
-        defer noop.deinit(allocator);
+        defer noop.deinit(allocator, null);
 
         try noop.parse(&ctx);
 

--- a/src/combn/combinator/mapto.zig
+++ b/src/combn/combinator/mapto.zig
@@ -28,6 +28,10 @@ pub fn MapTo(comptime Payload: type, comptime Value: type, comptime Target: type
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: MapToContext(Payload, Value, Target)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, Target), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             self.input.parser.deinit(allocator, freed);

--- a/src/combn/combinator/mapto.zig
+++ b/src/combn/combinator/mapto.zig
@@ -103,7 +103,7 @@ test "mapto" {
         defer ctx.deinit();
 
         const mapTo = try MapTo(Payload, LiteralValue, String).init(allocator, .{
-            .parser = (&Literal(Payload).init("hello").parser).ref(),
+            .parser = (try Literal(Payload).init(allocator, "hello")).ref(),
             .mapTo = struct {
                 fn mapTo(in: Result(LiteralValue), payload: Payload, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(String) {
                     _ = payload;

--- a/src/combn/combinator/oneof.zig
+++ b/src/combn/combinator/oneof.zig
@@ -47,6 +47,10 @@ pub fn OneOf(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: OneOfContext(Payload, Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             for (self.input) |in_parser| {

--- a/src/combn/combinator/oneof.zig
+++ b/src/combn/combinator/oneof.zig
@@ -129,8 +129,8 @@ test "oneof" {
         defer ctx.deinit();
 
         const parsers: []*Parser(Payload, LiteralValue) = &.{
-            (&Literal(Payload).init("ello").parser).ref(),
-            (&Literal(Payload).init("world").parser).ref(),
+            (try Literal(Payload).init(allocator, "ello")).ref(),
+            (try Literal(Payload).init(allocator, "world")).ref(),
         };
         var helloOrWorld = try OneOf(Payload, LiteralValue).init(allocator, parsers);
         defer helloOrWorld.deinit(allocator, null);
@@ -160,8 +160,8 @@ test "oneof_ambiguous_first" {
         defer ctx.deinit();
 
         const parsers: []*Parser(Payload, LiteralValue) = &.{
-            (&Literal(Payload).init("ello").parser).ref(),
-            (&Literal(Payload).init("elloworld").parser).ref(),
+            (try Literal(Payload).init(allocator, "ello")).ref(),
+            (try Literal(Payload).init(allocator, "elloworld")).ref(),
         };
         var helloOrWorld = try OneOf(Payload, LiteralValue).init(allocator, parsers);
         defer helloOrWorld.deinit(allocator, null);

--- a/src/combn/combinator/oneof.zig
+++ b/src/combn/combinator/oneof.zig
@@ -37,7 +37,7 @@ pub fn OneOfValue(comptime Value: type) type {
 /// The `input` parsers must remain alive for as long as the `OneOf` parser will be used.
 pub fn OneOf(comptime Payload: type, comptime Value: type) type {
     return struct {
-        parser: Parser(Payload, OneOfValue(Value)) = Parser(Payload, OneOfValue(Value)).init(parse, nodeName, deinit),
+        parser: Parser(Payload, OneOfValue(Value)) = Parser(Payload, OneOfValue(Value)).init(parse, nodeName, deinit, countReferencesTo),
         input: OneOfContext(Payload, Value),
 
         const Self = @This();
@@ -46,11 +46,21 @@ pub fn OneOf(comptime Payload: type, comptime Value: type) type {
             return Self{ .input = input };
         }
 
-        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator) void {
+        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             for (self.input) |in_parser| {
-                in_parser.deinit(allocator);
+                in_parser.deinit(allocator, freed);
             }
+        }
+
+        pub fn countReferencesTo(parser: *const Parser(Payload, Value), other: usize, freed: *std.AutoHashMap(usize, void)) usize {
+            const self = @fieldParentPtr(Self, "parser", parser);
+            if (@ptrToInt(parser) == other) return 1;
+            var count: usize = 0;
+            for (self.input) |in_parser| {
+                count += in_parser.countReferencesTo(other, freed);
+            }
+            return count;
         }
 
         pub fn nodeName(parser: *const Parser(Payload, Value), node_name_cache: *std.AutoHashMap(usize, ParserNodeName)) Error!u64 {

--- a/src/combn/combinator/oneof_ambiguous.zig
+++ b/src/combn/combinator/oneof_ambiguous.zig
@@ -157,8 +157,8 @@ test "oneof" {
         defer ctx.deinit();
 
         const parsers: []*Parser(Payload, LiteralValue) = &.{
-            (&Literal(Payload).init("ello").parser).ref(),
-            (&Literal(Payload).init("world").parser).ref(),
+            (try Literal(Payload).init(allocator, "ello")).ref(),
+            (try Literal(Payload).init(allocator, "world")).ref(),
         };
         var helloOrWorld = try OneOfAmbiguous(Payload, LiteralValue).init(allocator, parsers);
         defer helloOrWorld.deinit(allocator, null);
@@ -186,8 +186,8 @@ test "oneof_ambiguous" {
         defer ctx.deinit();
 
         const parsers: []*Parser(Payload, LiteralValue) = &.{
-            (&Literal(Payload).init("ello").parser).ref(),
-            (&Literal(Payload).init("elloworld").parser).ref(),
+            (try Literal(Payload).init(allocator, "ello")).ref(),
+            (try Literal(Payload).init(allocator, "elloworld")).ref(),
         };
         var helloOrWorld = try OneOfAmbiguous(Payload, LiteralValue).init(allocator, parsers);
         defer helloOrWorld.deinit(allocator, null);

--- a/src/combn/combinator/oneof_ambiguous.zig
+++ b/src/combn/combinator/oneof_ambiguous.zig
@@ -58,6 +58,10 @@ pub fn OneOfAmbiguous(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: OneOfAmbiguousContext(Payload, Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             for (self.input) |in_parser| {

--- a/src/combn/combinator/optional.zig
+++ b/src/combn/combinator/optional.zig
@@ -78,7 +78,7 @@ test "optional_some" {
         const ctx = try Context(Payload, ?LiteralValue).init(allocator, "hello world", {});
         defer ctx.deinit();
 
-        const optional = try Optional(Payload, LiteralValue).init(allocator, (&Literal(Payload).init("hello").parser).ref());
+        const optional = try Optional(Payload, LiteralValue).init(allocator, (try Literal(Payload).init(allocator, "hello")).ref());
         defer optional.deinit(allocator, null);
 
         try optional.parse(&ctx);
@@ -99,7 +99,7 @@ test "optional_none" {
         const ctx = try Context(Payload, ?LiteralValue).init(allocator, "hello world", {});
         defer ctx.deinit();
 
-        const optional = try Optional(Payload, LiteralValue).init(allocator, (&Literal(Payload).init("world").parser).ref());
+        const optional = try Optional(Payload, LiteralValue).init(allocator, (try Literal(Payload).init(allocator, "world")).ref());
         defer optional.deinit(allocator, null);
 
         try optional.parse(&ctx);

--- a/src/combn/combinator/optional.zig
+++ b/src/combn/combinator/optional.zig
@@ -25,6 +25,10 @@ pub fn Optional(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: OptionalContext(Payload, Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, ?Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             self.input.deinit(allocator, freed);

--- a/src/combn/combinator/reentrant.zig
+++ b/src/combn/combinator/reentrant.zig
@@ -32,8 +32,9 @@ pub fn Reentrant(comptime Payload: type, comptime Value: type) type {
 
         const Self = @This();
 
-        pub fn init(input: ReentrantContext(Payload, Value)) Self {
-            return Self{ .input = input };
+        pub fn init(allocator: *mem.Allocator, input: ReentrantContext(Payload, Value)) !*Parser(Payload, Value) {
+            const self = Self{ .input = input };
+            return try self.parser.heapAlloc(allocator, self);
         }
 
         pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {

--- a/src/combn/combinator/reentrant.zig
+++ b/src/combn/combinator/reentrant.zig
@@ -37,6 +37,10 @@ pub fn Reentrant(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: ReentrantContext(Payload, Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             self.input.deinit(allocator, freed);

--- a/src/combn/combinator/reentrant.zig
+++ b/src/combn/combinator/reentrant.zig
@@ -27,7 +27,7 @@ pub fn ReentrantContext(comptime Payload: type, comptime Value: type) type {
 /// The `input.parser` must remain alive for as long as the `Reentrant` parser will be used.
 pub fn Reentrant(comptime Payload: type, comptime Value: type) type {
     return struct {
-        parser: Parser(Payload, Value) = Parser(Payload, Value).init(parse, nodeName, deinit),
+        parser: Parser(Payload, Value) = Parser(Payload, Value).init(parse, nodeName, deinit, countReferencesTo),
         input: ReentrantContext(Payload, Value),
 
         const Self = @This();
@@ -36,9 +36,15 @@ pub fn Reentrant(comptime Payload: type, comptime Value: type) type {
             return Self{ .input = input };
         }
 
-        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator) void {
+        pub fn deinit(parser: *Parser(Payload, Value), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
-            self.input.deinit(allocator);
+            self.input.deinit(allocator, freed);
+        }
+
+        pub fn countReferencesTo(parser: *const Parser(Payload, Value), other: usize, freed: *std.AutoHashMap(usize, void)) usize {
+            const self = @fieldParentPtr(Self, "parser", parser);
+            if (@ptrToInt(parser) == other) return 1;
+            return self.input.countReferencesTo(other, freed);
         }
 
         pub fn nodeName(parser: *const Parser(Payload, Value), node_name_cache: *std.AutoHashMap(usize, ParserNodeName)) Error!u64 {

--- a/src/combn/combinator/repeated.zig
+++ b/src/combn/combinator/repeated.zig
@@ -156,7 +156,7 @@ test "repeated" {
         defer ctx.deinit();
 
         var abcInfinity = try Repeated(Payload, LiteralValue).init(allocator, .{
-            .parser = (&Literal(Payload).init("abc").parser).ref(),
+            .parser = (try Literal(Payload).init(allocator, "abc")).ref(),
             .min = 0,
             .max = -1,
         });

--- a/src/combn/combinator/repeated.zig
+++ b/src/combn/combinator/repeated.zig
@@ -56,6 +56,10 @@ pub fn Repeated(comptime Payload: type, comptime Value: type) type {
             return try self.parser.heapAlloc(allocator, self);
         }
 
+        pub fn initStack(input: RepeatedContext(Payload, Value)) Self {
+            return Self{ .input = input };
+        }
+
         pub fn deinit(parser: *Parser(Payload, RepeatedValue(Value)), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             self.input.parser.deinit(allocator, freed);

--- a/src/combn/combinator/repeated_ambiguous.zig
+++ b/src/combn/combinator/repeated_ambiguous.zig
@@ -277,7 +277,7 @@ test "repeated" {
         defer ctx.deinit();
 
         var abcInfinity = try RepeatedAmbiguous(Payload, LiteralValue).init(allocator, .{
-            .parser = (&Literal(Payload).init("abc").parser).ref(),
+            .parser = (try Literal(Payload).init(allocator, "abc")).ref(),
             .min = 0,
             .max = -1,
         });

--- a/src/combn/combinator/repeated_ambiguous.zig
+++ b/src/combn/combinator/repeated_ambiguous.zig
@@ -96,8 +96,9 @@ pub fn RepeatedAmbiguous(comptime Payload: type, comptime Value: type) type {
 
         const Self = @This();
 
-        pub fn init(input: RepeatedAmbiguousContext(Payload, Value)) Self {
-            return Self{ .input = input };
+        pub fn init(allocator: *mem.Allocator, input: RepeatedAmbiguousContext(Payload, Value)) !*Parser(Payload, RepeatedAmbiguousValue(Value)) {
+            const self = Self{ .input = input };
+            return try self.parser.heapAlloc(allocator, self);
         }
 
         pub fn deinit(parser: *Parser(Payload, RepeatedAmbiguousValue(Value)), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
@@ -230,15 +231,16 @@ pub fn RepeatedAmbiguous(comptime Payload: type, comptime Value: type) type {
                         // associated with A, B, C.)
                         var path_results = try ctx.allocator.create(ResultStream(Result(RepeatedAmbiguousValue(Value))));
                         path_results.* = try ResultStream(Result(RepeatedAmbiguousValue(Value))).init(ctx.allocator, ctx.key);
-                        var path = RepeatedAmbiguous(Payload, Value).init(.{
+                        var path = try RepeatedAmbiguous(Payload, Value).init(ctx.allocator, .{
                             .parser = self.input.parser,
                             .min = self.input.min,
                             .max = if (self.input.max == -1) -1 else self.input.max - 1,
                         });
-                        const path_node_name = try path.parser.nodeName(&in_ctx.memoizer.node_name_cache);
+                        defer path.deinit(ctx.allocator, null);
+                        const path_node_name = try path.nodeName(&in_ctx.memoizer.node_name_cache);
                         var path_ctx = try in_ctx.initChild(RepeatedAmbiguousValue(Value), path_node_name, top_level.offset);
                         defer path_ctx.deinitChild();
-                        if (!path_ctx.existing_results) try path.parser.parse(&path_ctx);
+                        if (!path_ctx.existing_results) try path.parse(&path_ctx);
                         var path_results_sub = path_ctx.subscribe();
                         while (path_results_sub.next()) |next| {
                             try path_results.add(next.toUnowned());
@@ -271,12 +273,13 @@ test "repeated" {
         const ctx = try Context(Payload, RepeatedAmbiguousValue(LiteralValue)).init(allocator, "abcabcabc123abc", {});
         defer ctx.deinit();
 
-        var abcInfinity = RepeatedAmbiguous(Payload, LiteralValue).init(.{
+        var abcInfinity = try RepeatedAmbiguous(Payload, LiteralValue).init(allocator, .{
             .parser = (&Literal(Payload).init("abc").parser).ref(),
             .min = 0,
             .max = -1,
         });
-        try abcInfinity.parser.parse(&ctx);
+        defer abcInfinity.deinit(allocator, null);
+        try abcInfinity.parse(&ctx);
 
         var sub = ctx.subscribe();
         var list = sub.next();

--- a/src/combn/combinator/sequence.zig
+++ b/src/combn/combinator/sequence.zig
@@ -145,10 +145,10 @@ test "sequence" {
         defer ctx.deinit();
 
         var seq = try Sequence(Payload, LiteralValue).init(allocator, &.{
-            (&Literal(Payload).init("abc").parser).ref(),
-            (&Literal(Payload).init("123ab").parser).ref(),
-            (&Literal(Payload).init("c45").parser).ref(),
-            (&Literal(Payload).init("6").parser).ref(),
+            (try Literal(Payload).init(allocator, "abc")).ref(),
+            (try Literal(Payload).init(allocator, "123ab")).ref(),
+            (try Literal(Payload).init(allocator, "c45")).ref(),
+            (try Literal(Payload).init(allocator, "6")).ref(),
         });
         defer seq.deinit(allocator, null);
         try seq.parse(&ctx);

--- a/src/combn/combinator/sequence_ambiguous.zig
+++ b/src/combn/combinator/sequence_ambiguous.zig
@@ -85,7 +85,7 @@ pub fn SequenceAmbiguousValue(comptime Value: type) type {
 /// The `input` parsers must remain alive for as long as the `SequenceAmbiguous` parser will be used.
 pub fn SequenceAmbiguous(comptime Payload: type, comptime Value: type) type {
     return struct {
-        parser: Parser(Payload, SequenceAmbiguousValue(Value)) = Parser(Payload, SequenceAmbiguousValue(Value)).init(parse, nodeName, deinit),
+        parser: Parser(Payload, SequenceAmbiguousValue(Value)) = Parser(Payload, SequenceAmbiguousValue(Value)).init(parse, nodeName, deinit, countReferencesTo),
         input: SequenceAmbiguousContext(Payload, Value),
 
         const Self = @This();
@@ -94,11 +94,21 @@ pub fn SequenceAmbiguous(comptime Payload: type, comptime Value: type) type {
             return Self{ .input = input };
         }
 
-        pub fn deinit(parser: *Parser(Payload, SequenceAmbiguousValue(Value)), allocator: *mem.Allocator) void {
+        pub fn deinit(parser: *Parser(Payload, SequenceAmbiguousValue(Value)), allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void {
             const self = @fieldParentPtr(Self, "parser", parser);
             for (self.input) |child_parser| {
-                child_parser.deinit(allocator);
+                child_parser.deinit(allocator, freed);
             }
+        }
+
+        pub fn countReferencesTo(parser: *const Parser(Payload, SequenceAmbiguousValue(Value)), other: usize, freed: *std.AutoHashMap(usize, void)) usize {
+            const self = @fieldParentPtr(Self, "parser", parser);
+            if (@ptrToInt(parser) == other) return 1;
+            var count: usize = 0;
+            for (self.input) |in_parser| {
+                count += in_parser.countReferencesTo(other, freed);
+            }
+            return count;
         }
 
         pub fn nodeName(parser: *const Parser(Payload, SequenceAmbiguousValue(Value)), node_name_cache: *std.AutoHashMap(usize, ParserNodeName)) Error!u64 {

--- a/src/combn/combinator/sequence_ambiguous.zig
+++ b/src/combn/combinator/sequence_ambiguous.zig
@@ -218,10 +218,10 @@ test "sequence" {
         defer ctx.deinit();
 
         var seq = try SequenceAmbiguous(Payload, LiteralValue).init(allocator, &.{
-            (&Literal(Payload).init("abc").parser).ref(),
-            (&Literal(Payload).init("123ab").parser).ref(),
-            (&Literal(Payload).init("c45").parser).ref(),
-            (&Literal(Payload).init("6").parser).ref(),
+            (try Literal(Payload).init(allocator, "abc")).ref(),
+            (try Literal(Payload).init(allocator, "123ab")).ref(),
+            (try Literal(Payload).init(allocator, "c45")).ref(),
+            (try Literal(Payload).init(allocator, "6")).ref(),
         });
         defer seq.deinit(allocator, null);
         try seq.parse(&ctx);

--- a/src/combn/engine/parser.zig
+++ b/src/combn/engine/parser.zig
@@ -550,7 +550,7 @@ test "heap_parser" {
 
         // The parser we'll store on the heap.
         var want = "hello";
-        var literal_parser = Literal(Payload).init(want);
+        var literal_parser = Literal(Payload).initStack(want);
 
         // Move to heap.
         var heap_parser = try literal_parser.parser.heapAlloc(allocator, literal_parser);

--- a/src/combn/engine/parser.zig
+++ b/src/combn/engine/parser.zig
@@ -441,7 +441,7 @@ pub fn Parser(comptime Payload: type, comptime Value: type) type {
         _parse: fn (self: *const Self, ctx: *const Context(Payload, Value)) callconv(.Async) Error!void,
         _nodeName: fn (self: *const Self, node_name_cache: *std.AutoHashMap(usize, ParserNodeName)) Error!u64,
         _deinit: ?fn (self: *Self, allocator: *mem.Allocator, freed: ?*std.AutoHashMap(usize, void)) void,
-        _countReferencesTo: ?fn(self: *const Self, other: usize, freed: *std.AutoHashMap(usize, void)) usize,
+        _countReferencesTo: ?fn (self: *const Self, other: usize, freed: *std.AutoHashMap(usize, void)) usize,
         _heap_storage: ?[]u8,
         _refs: usize,
 

--- a/src/combn/parser/byte_range.zig
+++ b/src/combn/parser/byte_range.zig
@@ -24,7 +24,7 @@ pub const ByteRangeValue = struct {
 /// Matches any single byte in the specified range.
 pub fn ByteRange(comptime Payload: type) type {
     return struct {
-        parser: Parser(Payload, ByteRangeValue) = Parser(Payload, ByteRangeValue).init(parse, nodeName, null),
+        parser: Parser(Payload, ByteRangeValue) = Parser(Payload, ByteRangeValue).init(parse, nodeName, null, null),
         input: ByteRangeContext,
 
         const Self = @This();

--- a/src/combn/parser/byte_range.zig
+++ b/src/combn/parser/byte_range.zig
@@ -29,7 +29,12 @@ pub fn ByteRange(comptime Payload: type) type {
 
         const Self = @This();
 
-        pub fn init(input: ByteRangeContext) Self {
+        pub fn init(allocator: *mem.Allocator, input: ByteRangeContext) !*Parser(Payload, ByteRangeValue) {
+            const self = Self{ .input = input };
+            return try self.parser.heapAlloc(allocator, self);
+        }
+
+        pub fn initStack(input: ByteRangeContext) Self {
             return Self{ .input = input };
         }
 
@@ -68,8 +73,9 @@ test "byte_range" {
         var ctx = try Context(Payload, ByteRangeValue).init(allocator, "hello world", {});
         defer ctx.deinit();
 
-        var any_byte = ByteRange(Payload).init(.{ .from = 0, .to = 255 });
-        try any_byte.parser.parse(&ctx);
+        var any_byte = try ByteRange(Payload).init(allocator, .{ .from = 0, .to = 255 });
+        defer any_byte.deinit(allocator, null);
+        try any_byte.parse(&ctx);
 
         var sub = ctx.subscribe();
         var first = sub.next().?;

--- a/src/combn/parser/end.zig
+++ b/src/combn/parser/end.zig
@@ -14,7 +14,7 @@ pub const EndValue = struct {
 /// Matches the end of the `input` string.
 pub fn End(comptime Payload: type) type {
     return struct {
-        parser: Parser(Payload, EndValue) = Parser(Payload, EndValue).init(parse, nodeName, null),
+        parser: Parser(Payload, EndValue) = Parser(Payload, EndValue).init(parse, nodeName, null, null),
 
         const Self = @This();
 

--- a/src/combn/parser/end.zig
+++ b/src/combn/parser/end.zig
@@ -18,7 +18,12 @@ pub fn End(comptime Payload: type) type {
 
         const Self = @This();
 
-        pub fn init() Self {
+        pub fn init(allocator: *mem.Allocator) !*Parser(Payload, EndValue) {
+            const self = Self{};
+            return try self.parser.heapAlloc(allocator, self);
+        }
+
+        pub fn initStack() Self {
             return Self{};
         }
 
@@ -51,8 +56,9 @@ test "end" {
         var ctx = try Context(Payload, EndValue).init(allocator, "", {});
         defer ctx.deinit();
 
-        var e = End(Payload).init();
-        try e.parser.parse(&ctx);
+        var e = try End(Payload).init(allocator);
+        defer e.deinit(allocator, null);
+        try e.parse(&ctx);
 
         var sub = ctx.subscribe();
         var first = sub.next().?;

--- a/src/combn/parser/literal.zig
+++ b/src/combn/parser/literal.zig
@@ -21,7 +21,7 @@ pub const LiteralValue = struct {
 /// The `input` string must remain alive for as long as the `Literal` parser will be used.
 pub fn Literal(comptime Payload: type) type {
     return struct {
-        parser: Parser(Payload, LiteralValue) = Parser(Payload, LiteralValue).init(parse, nodeName, null),
+        parser: Parser(Payload, LiteralValue) = Parser(Payload, LiteralValue).init(parse, nodeName, null, null),
         input: LiteralContext,
 
         const Self = @This();

--- a/src/combn/test_complex.zig
+++ b/src/combn/test_complex.zig
@@ -34,7 +34,7 @@ test "direct_left_recursion_empty_language" {
             undefined, // placeholder for left-recursive Expr itself
         };
         var expr = try MapTo(Payload, SequenceAmbiguousValue(node), node).init(allocator, .{
-            .parser = (&SequenceAmbiguous(Payload, node).init(&parsers).parser).ref(),
+            .parser = (try SequenceAmbiguous(Payload, node).init(allocator, &parsers)).ref(),
             .mapTo = struct {
                 fn mapTo(in: Result(SequenceAmbiguousValue(node)), payload: Payload, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(node) {
                     _ = payload;
@@ -113,7 +113,7 @@ test "direct_left_recursion" {
     var expr = try Reentrant(Payload, node).init(
         allocator,
         try MapTo(Payload, SequenceAmbiguousValue(node), node).init(allocator, .{
-            .parser = (&SequenceAmbiguous(Payload, node).init(&parsers).parser).ref(),
+            .parser = (try SequenceAmbiguous(Payload, node).init(allocator, &parsers)).ref(),
             .mapTo = struct {
                 fn mapTo(in: Result(SequenceAmbiguousValue(node)), payload: Payload, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(node) {
                     _ = payload;

--- a/src/combn/test_complex.zig
+++ b/src/combn/test_complex.zig
@@ -87,7 +87,7 @@ test "direct_left_recursion" {
     defer ctx.deinit();
 
     var abcAsNode = try MapTo(Payload, LiteralValue, node).init(allocator, .{
-        .parser = (&Literal(Payload).init("abc").parser).ref(),
+        .parser = (try Literal(Payload).init(allocator, "abc")).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(LiteralValue), payload: Payload, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(node) {
                 _ = _allocator;

--- a/src/combn/test_complex.zig
+++ b/src/combn/test_complex.zig
@@ -49,7 +49,7 @@ test "direct_left_recursion_empty_language" {
                 }
             }.mapTo,
         });
-        defer expr.deinit(allocator);
+        defer expr.deinit(allocator, null);
         parsers[0] = expr.ref();
         try expr.parse(&ctx);
 
@@ -105,7 +105,6 @@ test "direct_left_recursion" {
             }
         }.mapTo,
     });
-    defer abcAsNode.deinit(allocator);
 
     var parsers = [_]*Parser(Payload, node){
         undefined, // placeholder for left-recursive Expr itself
@@ -166,7 +165,7 @@ test "direct_left_recursion" {
             }
         }.mapTo,
     });
-    defer optionalExpr.deinit(allocator);
+    defer optionalExpr.deinit(allocator, null);
     parsers[0] = optionalExpr.ref();
     try expr.parser.parse(&ctx);
 

--- a/src/combn/test_complex.zig
+++ b/src/combn/test_complex.zig
@@ -142,7 +142,7 @@ test "direct_left_recursion" {
         }),
     );
     var optionalExpr = try MapTo(Payload, ?node, node).init(allocator, .{
-        .parser = (&Optional(Payload, node).init((&expr.parser).ref()).parser).ref(),
+        .parser = (try Optional(Payload, node).init(allocator, (&expr.parser).ref())).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(?node), payload: Payload, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(node) {
                 _ = payload;

--- a/src/dsl/Compilation.zig
+++ b/src/dsl/Compilation.zig
@@ -24,7 +24,7 @@ pub const CompiledParser = struct {
     slice: ?[]*const Parser(void, *Node),
 
     pub fn deinit(self: @This(), allocator: *mem.Allocator) void {
-        self.ptr.deinit(allocator);
+        self.ptr.deinit(allocator, null);
         if (self.slice) |slice| {
             allocator.free(slice);
         }

--- a/src/dsl/compiler.zig
+++ b/src/dsl/compiler.zig
@@ -133,16 +133,16 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
 
     var newline = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
         .parser = (try OneOf(*CompilerContext, LiteralValue).init(allocator, &.{
-            (&Literal(*CompilerContext).init("\r\n").parser).ref(),
-            (&Literal(*CompilerContext).init("\r").parser).ref(),
-            (&Literal(*CompilerContext).init("\n").parser).ref(),
+            (try Literal(*CompilerContext).init(allocator, "\r\n")).ref(),
+            (try Literal(*CompilerContext).init(allocator, "\r")).ref(),
+            (try Literal(*CompilerContext).init(allocator, "\n")).ref(),
         })).ref(),
         .mapTo = mapLiteralToNone,
     });
     var space = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
         .parser = (try OneOf(*CompilerContext, LiteralValue).init(allocator, &.{
-            (&Literal(*CompilerContext).init(" ").parser).ref(),
-            (&Literal(*CompilerContext).init("\t").parser).ref(),
+            (try Literal(*CompilerContext).init(allocator, " ")).ref(),
+            (try Literal(*CompilerContext).init(allocator, "\t")).ref(),
         })).ref(),
         .mapTo = mapLiteralToNone,
     });
@@ -176,15 +176,15 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
     });
 
     var assignment = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
-        .parser = (&Literal(*CompilerContext).init("=").parser).ref(),
+        .parser = (try Literal(*CompilerContext).init(allocator, "=")).ref(),
         .mapTo = mapLiteralToNone,
     });
     var semicolon = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
-        .parser = (&Literal(*CompilerContext).init(";").parser).ref(),
+        .parser = (try Literal(*CompilerContext).init(allocator, ";")).ref(),
         .mapTo = mapLiteralToNone,
     });
     var forward_slash = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
-        .parser = (&Literal(*CompilerContext).init("/").parser).ref(),
+        .parser = (try Literal(*CompilerContext).init(allocator, "/")).ref(),
         .mapTo = mapLiteralToNone,
     });
 
@@ -260,7 +260,7 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
     });
     // (ExprList, ",")
     var comma = try MapTo(*CompilerContext, LiteralValue, ?Compilation).init(allocator, .{
-        .parser = (&Literal(*CompilerContext).init(",").parser).ref(),
+        .parser = (try Literal(*CompilerContext).init(allocator, ",")).ref(),
         .mapTo = mapLiteralToNone,
     });
     var expr_list_inner_left = try MapTo(*CompilerContext, SequenceValue(?Compilation), ?Compilation).init(allocator, .{

--- a/src/dsl/compiler.zig
+++ b/src/dsl/compiler.zig
@@ -222,7 +222,7 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
     });
 
     var identifier_expr = try MapTo(*CompilerContext, ?Compilation, ?Compilation).init(allocator, .{
-        .parser = (&Identifier.init().parser).ref(),
+        .parser = (try Identifier.init(allocator)).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(?Compilation), compiler_context: *CompilerContext, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(?Compilation) {
                 _ = _allocator;
@@ -311,7 +311,7 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
 
     var definition = try MapTo(*CompilerContext, SequenceValue(?Compilation), ?Compilation).init(allocator, .{
         .parser = (try Sequence(*CompilerContext, ?Compilation).init(allocator, &.{
-            (&Identifier.init().parser).ref(),
+            (try Identifier.init(allocator)).ref(),
             whitespace_one_or_more.ref(),
             assignment.ref(),
             whitespace_one_or_more.ref(),

--- a/src/dsl/compiler.zig
+++ b/src/dsl/compiler.zig
@@ -153,11 +153,11 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
         space.ref(),
     });
     var whitespace_one_or_more = try MapTo(*CompilerContext, RepeatedValue(?Compilation), ?Compilation).init(allocator, .{
-        .parser = (&Repeated(*CompilerContext, ?Compilation).init(.{
+        .parser = (try Repeated(*CompilerContext, ?Compilation).init(allocator, .{
             .parser = whitespace.ref(),
             .min = 1,
             .max = -1,
-        }).parser).ref(),
+        })).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(RepeatedValue(?Compilation)), compiler_context: *CompilerContext, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(?Compilation) {
                 _ = compiler_context;
@@ -361,11 +361,11 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
 
     // TODO(slimsag): match EOF
     var grammar = try MapTo(*CompilerContext, RepeatedValue(?Compilation), Compilation).init(allocator, .{
-        .parser = (&Repeated(*CompilerContext, ?Compilation).init(.{
+        .parser = (try Repeated(*CompilerContext, ?Compilation).init(allocator, .{
             .parser = definition_or_expr_or_whitespace.ref(),
             .min = 1,
             .max = -1,
-        }).parser).ref(),
+        })).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(RepeatedValue(?Compilation)), compiler_context: *CompilerContext, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(Compilation) {
                 _ = compiler_context;

--- a/src/dsl/compiler.zig
+++ b/src/dsl/compiler.zig
@@ -209,10 +209,10 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
                         // TODO(slimsag): actually compose the compilation to parse this regexp!
                         const node = try Node.init(_allocator, String.init("TODO(slimsag): value from parsing regexp!"), null);
                         const success = Result(*Node).init(in.offset, node);
-                        var always_success = Always(void, *Node).init(success);
+                        var always_success = try Always(void, *Node).init(_allocator, success);
 
                         var result_compilation = Compilation.initParser(Compilation.CompiledParser{
-                            .ptr = try always_success.parser.heapAlloc(_allocator, always_success),
+                            .ptr = always_success,
                             .slice = null,
                         });
                         return Result(?Compilation).init(in.offset, result_compilation);

--- a/src/dsl/compiler.zig
+++ b/src/dsl/compiler.zig
@@ -289,7 +289,7 @@ pub fn compile(allocator: *mem.Allocator, syntax: []const u8) !CompilerResult {
         }.mapTo,
     });
     var optional_expr_list_inner_left = try MapTo(*CompilerContext, ??Compilation, ?Compilation).init(allocator, .{
-        .parser = (&Optional(*CompilerContext, ?Compilation).init(expr_list_inner_left.ref()).parser).ref(),
+        .parser = (try Optional(*CompilerContext, ?Compilation).init(allocator, expr_list_inner_left.ref())).ref(),
         .mapTo = struct {
             fn mapTo(in: Result(??Compilation), compiler_context: *CompilerContext, _allocator: *mem.Allocator, key: ParserPosKey, path: ParserPath) callconv(.Async) Error!?Result(?Compilation) {
                 _ = compiler_context;

--- a/src/dsl/identifier.zig
+++ b/src/dsl/identifier.zig
@@ -23,7 +23,12 @@ pub const Identifier = struct {
 
     const Self = @This();
 
-    pub fn init() Self {
+    pub fn init(allocator: *mem.Allocator) !*Parser(*CompilerContext, ?Compilation) {
+        const self = Self{};
+        return try self.parser.heapAlloc(allocator, self);
+    }
+
+    pub fn initStack() Self {
         return Self{};
     }
 
@@ -76,8 +81,9 @@ test "identifier" {
         var ctx = try Context(*CompilerContext, ?Compilation).init(allocator, "Grammar2", compilerContext);
         defer ctx.deinit();
 
-        var l = Identifier.init();
-        try l.parser.parse(&ctx);
+        var l = try Identifier.init(allocator);
+        defer l.deinit(allocator, null);
+        try l.parse(&ctx);
 
         var sub = ctx.subscribe();
         var r1 = sub.next().?;

--- a/src/dsl/identifier.zig
+++ b/src/dsl/identifier.zig
@@ -19,7 +19,7 @@ const mem = std.mem;
 ///
 /// The `input` string must remain alive for as long as the `Identifier` parser will be used.
 pub const Identifier = struct {
-    parser: Parser(*CompilerContext, ?Compilation) = Parser(*CompilerContext, ?Compilation).init(parse, nodeName, null),
+    parser: Parser(*CompilerContext, ?Compilation) = Parser(*CompilerContext, ?Compilation).init(parse, nodeName, null, null),
 
     const Self = @This();
 


### PR DESCRIPTION
Today, parsers are primarily stack allocated. This was a desirable property, especially when working with very small grammars / compositions of parser combinators, but as grammars grow you quickly end up with intangible quite long single-functions like `pub fn compile` in `src/dsl/compiler.zig`. The reason for this is simple: without heap allocating parsers within the grammar, the composed grammar cannot be parsed outside the scope of that function.

This change moves all parsers and combinators to effectively be heap allocated by default, thus enabling one to write functions composing parsers as you would want to naturally without having to deal with the (rather complex) memory management semantics, noting that many grammars involve cyclically referenced parsers.

This does introduce some complexity in terms of reference counting due to the cyclic references, however it seems well worth it for the much improved refactorability of code alone.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.